### PR TITLE
fix(PostHeader): correctly compute hlocation

### DIFF
--- a/components/VPLPostHeader.vue
+++ b/components/VPLPostHeader.vue
@@ -72,7 +72,7 @@ const hdate = computed(() => {
 });
 
 const hlocation = computed(() => {
-  return frontmatter.value?.location ?? author?.location ?? false;
+  return frontmatter.value?.location ?? authors?.[0]?.location ?? false;
 });
 
 </script>


### PR DESCRIPTION
I'm getting the following error:

```
ReferenceError: author is not defined
```

Probably an oversight when switching from author to authors. I fixed it here by using the first author's location instead.