### PR TITLE
fix(defaults): don't enable carbonAds by default

### DIFF
--- a/config/defaults.js
+++ b/config/defaults.js
@@ -22,10 +22,7 @@ export default function({base}) {
     themeConfig: {
       alert: false,
       autometa: false,
-      carbonAds: {
-        code: 'CE7DCKJU',
-        placement: 'landodev',
-      },
+      carbonAds: undefined,
       collections: {
         post: {
           frontmatter: {


### PR DESCRIPTION
There should not be a default value for carbonAds, especially since it can't be unset (setting `undefined` will just be overridden by your default). 