### PR TITLE
fix(member): only render member data if provided

### DIFF
--- a/components/VPLTeamMembersItem.vue
+++ b/components/VPLTeamMembersItem.vue
@@ -122,10 +122,10 @@ const getLink = member => {
 };
 
 const getAvatarTitle = member => {
-  let avatarTitle = `${member.name}`
-  if (member.email) avatarTitle += ` <${member.email}>`
-  if (member.commits) avatarTitle += ` - ${Number.parseInt(member.commits, 10)} commits`
-  return avatarTitle
+  let avatarTitle = `${member.name}`;
+  if (member.email) avatarTitle += ` <${member.email}>`;
+  if (member.commits) avatarTitle += ` - ${Number.parseInt(member.commits, 10)} commits`;
+  return avatarTitle;
 };
 
 </script>

--- a/components/VPLTeamMembersItem.vue
+++ b/components/VPLTeamMembersItem.vue
@@ -19,7 +19,7 @@
             class="avatar-img"
             :src="avatar"
             :alt="`Picture of ${member.name}`"
-            :title="`${member.name} <${member.email}> - ${Number.parseInt(member.commits, 10)} commits`"
+            :title="getAvatarTitle(member)"
           >
         </Link>
       </figure>
@@ -119,6 +119,13 @@ const getLink = member => {
   if (member.link) return member.link;
   else if (Array.isArray(member?.links) && member.links[0]) return member.links[0].link;
   else if (member.email) return `mailto:${member.email}`;
+};
+
+const getAvatarTitle = member => {
+  let avatarTitle = `${member.name}`
+  if (member.email) avatarTitle += ` <${member.email}>`
+  if (member.commits avatarTitle += ` - ${Number.parseInt(member.commits, 10)} commits`
+  return avatarTitle
 };
 
 </script>

--- a/components/VPLTeamMembersItem.vue
+++ b/components/VPLTeamMembersItem.vue
@@ -124,7 +124,7 @@ const getLink = member => {
 const getAvatarTitle = member => {
   let avatarTitle = `${member.name}`
   if (member.email) avatarTitle += ` <${member.email}>`
-  if (member.commits avatarTitle += ` - ${Number.parseInt(member.commits, 10)} commits`
+  if (member.commits) avatarTitle += ` - ${Number.parseInt(member.commits, 10)} commits`
   return avatarTitle
 };
 


### PR DESCRIPTION
If email and commits is not provided (in my case), the avatar title becomes `Manoah <undefined> - NaN commits`.

This PR fixes that and only adds the email/commits part if that data is provided.