### PR TITLE
chore: define new contributor

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -91,6 +91,16 @@ export default defineConfig({
           sponsor: 'https://lando.dev/sponsor',
           mergeOnly: true,
         },
+        {
+          avatar: 'https://avatars.githubusercontent.com/u/46671786',
+          name: 'Manoah Tervoort',
+          email: '149895ja@gmail.com',
+          title: 'Contributor',
+          links: [
+            {icon: 'github', link: 'https://github.com/mtdvlpr'},
+          ],
+          mergeOnly: true,
+        },
       ],
     },
     editLink: {pattern: 'https://github.com/lando/vitepress-theme-default-plus/edit/main/docs/:path'},


### PR DESCRIPTION
I'm automatically present in your team page: https://vitepress-theme-default-plus.lando.dev/team.html

I might as well add some meta data about myself, so I'm displayed correctly :)