### PR TITLE
fix: render docsearch hit rows

### DIFF
--- a/components/VPLAlgoliaSearchBox.vue
+++ b/components/VPLAlgoliaSearchBox.vue
@@ -45,6 +45,13 @@ async function update() {
   });
 }
 
+// DocSearch bundles Preact, whose diff fast-path short-circuits when
+// newVnode.__v == oldVnode.__v (loose == since @docsearch/js 3.9.x).
+// A null __v collides on every render → blank .DocSearch-Hit rows.
+// Give each vnode a unique id to force the full diff path.
+// See: https://github.com/lando/vitepress-theme-default-plus/issues/98
+let hitVNodeId = 0;
+
 function initialize(userOptions = {}) {
   const options = Object.assign({}, userOptions, {
     container: '#docsearch',
@@ -65,11 +72,10 @@ function initialize(userOptions = {}) {
 
     hitComponent({hit, children}) {
       return {
-        __v: null,
+        __v: ++hitVNodeId, // see hitVNodeId comment above
         type: 'a',
         ref: undefined,
         constructor: undefined,
-        target: '_blank',
         key: undefined,
         props: {href: hit.url, children, target: '_self'},
       };


### PR DESCRIPTION
Fixes #98 — DocSearch results render as blank rows in live search.

## Root cause

DocSearch bundles its own copy of Preact (10.x). When Preact diffs a string-type vnode (our fabricated `'a'` element for each hit), it hits a fast-path that short-circuits reconciliation when:

```
excessDomChildren == null && newVnode.__v == oldVnode.__v
```

During state-triggered re-renders `excessDomChildren` is always `null`, so with `__v: null` the comparison collapses to `null == null && null == null` → Preact copies the old vnode's children/DOM onto the new vnode and skips diffing, producing a blank `.DocSearch-Hit` row.

Preact's equality operator also changed across versions:

- **≤3.8.x** — strict `===`: first render is fine, but every subsequent result update reuses stale DOM
- **3.9.x+** — loose `==`: even the first render fails (`null == undefined` is truthy)

Consumer projects (e.g. `lando/core`) resolve `@docsearch/js` to 3.9.x, so every search returned blank rows from the moment the modal opened.

## Fix

Assign a unique monotonic id to each hit vnode's `__v` so `newVnode.__v == oldVnode.__v` is never true and the full diff path runs. Also drops an invalid stray top-level `target` field that was never used (target belongs in `props`).

Fixes #98
